### PR TITLE
Make getItemValue required

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -6,13 +6,14 @@ let _debugStates = []
 let Autocomplete = React.createClass({
 
   propTypes: {
+    getItemValue: React.PropTypes.func.isRequired,
     initialValue: React.PropTypes.any,
+    inputProps: React.PropTypes.object,
+    menuStyle: React.PropTypes.object,
     onChange: React.PropTypes.func,
     onSelect: React.PropTypes.func,
-    shouldItemRender: React.PropTypes.func,
     renderItem: React.PropTypes.func.isRequired,
-    menuStyle: React.PropTypes.object,
-    inputProps: React.PropTypes.object
+    shouldItemRender: React.PropTypes.func
   },
 
   getDefaultProps () {


### PR DESCRIPTION
Without getItemValue set, the component errors when typing.
In addition, sorted the propTypes alphabetically.