### PR TITLE
[fixed]: check item length before calling scrollinto view

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -68,7 +68,7 @@ let Autocomplete = React.createClass({
   },
 
   maybeScrollItemIntoView () {
-    if (this.state.isOpen === true && this.state.highlightedIndex !== null) {
+    if (this.state.isOpen === true && this.state.highlightedIndex !== null && this.getFilteredItems().length > 0) {
       var itemNode = React.findDOMNode(this.refs[`item-${this.state.highlightedIndex}`])
       var menuNode = React.findDOMNode(this.refs.menu)
       scrollIntoView(itemNode, menuNode, { onlyScrollIfNeeded: true })


### PR DESCRIPTION
the state of highlightIndex will not be set to null when I change
the value of input box, so exception will be thrown when it is going
to find the highlighted dom element