### PR TITLE
Allows onBlur function to be set as additional component prop

### DIFF
--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -270,19 +270,6 @@ let Autocomplete = React.createClass({
     return React.cloneElement(menu, { ref: 'menu' })
   },
 
-  getActiveItemValue () {
-    if (this.state.highlightedIndex === null)
-      return ''
-    else {
-      var item = this.props.items[this.state.highlightedIndex]
-      // items can match when we maybeAutoCompleteText, but then get replaced by the app
-      // for the next render? I think? TODO: file an issue (alab -> enter -> type 'a' for
-      // alabamaa and then an error would happen w/o this guard, pretty sure there's a
-      // better way)
-      return item ? this.props.getItemValue(item) : ''
-    }
-  },
-
   handleInputBlur () {
     if (this._ignoreBlur)
       return
@@ -316,7 +303,6 @@ let Autocomplete = React.createClass({
           {...this.props.inputProps}
           role="combobox"
           aria-autocomplete="both"
-          aria-label={this.getActiveItemValue()}
           ref="input"
           onFocus={this.handleInputFocus}
           onBlur={this.handleInputBlur}

--- a/lib/Autocomplete.js
+++ b/lib/Autocomplete.js
@@ -9,6 +9,7 @@ let Autocomplete = React.createClass({
     initialValue: React.PropTypes.any,
     onChange: React.PropTypes.func,
     onSelect: React.PropTypes.func,
+    onBlur: React.PropTypes.func,
     shouldItemRender: React.PropTypes.func,
     renderItem: React.PropTypes.func.isRequired,
     menuStyle: React.PropTypes.object,
@@ -276,6 +277,10 @@ let Autocomplete = React.createClass({
     this.setState({
       isOpen: false,
       highlightedIndex: null
+    }, () => {
+      if (this.props.onBlur) {
+        this.props.onBlur(this.state.value)
+      }
     })
   },
 


### PR DESCRIPTION
This change enables an onBlur function to be set as an additional prop of the component, which is then called via the component's handleInputBlur function (passing the value of the input box as a parameter).

I am currently working on an application where I need this functionality, so that the value of the input box can be processed by the parent component on a blur event. This is a useful addition to the existing onChange prop (called when the user types a character) and onSelect prop (called when an autocomplete option is selected). For my application I specifically need to know the value on the onBlur event so that this value can be saved at that point.